### PR TITLE
Fix uninitialized username

### DIFF
--- a/src/Grandeljay/Availability/UserAvailabilities.php
+++ b/src/Grandeljay/Availability/UserAvailabilities.php
@@ -20,11 +20,9 @@ class UserAvailabilities extends UserAvailabilitiesIterator
         );
 
         foreach ($filenames as $filename) {
-            $filepath                 = $directory . '/' . $filename;
-            $userAvailabilityContents = file_get_contents($filepath);
-            $userAvailabilityData     = json_decode($userAvailabilityContents, true);
-            $userAvailability         = new UserAvailability($userAvailabilityData);
+            $filepath = $directory . '/' . $filename;
 
+            $userAvailability = UserAvailability::fromFile($filepath);
             $userAvailabilities->add($userAvailability);
         }
 


### PR DESCRIPTION
## Description

Fixes a bug that led to errors like this:

```
Uncaught Error: Typed property Grandeljay\Availability\UserAvailability::$userName must not be accessed before initialization in src/Grandeljay/Availability/UserAvailability.php:165
```

### Steps to Reproduce

1. Clear the availabilities directory (make sure it's empty)
2. Start the bot
3. Run an `/available` command
4. Watch it burn without the fix

## Pre-merge TODOs

- * ~~Merge #11~~